### PR TITLE
Publish the result to HTML

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,78 +1,102 @@
-const messageMaker = require('sitespeed.io/lib/support/messageMaker');
-const analyzer = require('./src/analyzer');
-const aggregator = require('./src/aggregator');
+const messageMaker = require("sitespeed.io/lib/support/messageMaker");
+const analyzer = require("./src/analyzer");
+const aggregator = require("./src/aggregator");
+const fs = require("fs");
+const path = require("path");
 
 // We need to prefix the plugin name with 'browsertime' to force
 // lib/plugins/graphite to add connectivity
 // https://github.com/sitespeedio/sitespeed.io/blob/master/lib/plugins/graphite/data-generator.js#L12
-const pluginName = 'browsertimeChrometrace';
+const pluginName = "browsertimeChrometrace";
 const make = messageMaker(pluginName).make;
 
 let runIndex = {};
 
 function processChrometraceMessage(message, queue, statsHelpers, options) {
-    const { url, group, data } = message;
-    const results = analyzer(data);
+  const { url, group, data } = message;
+  const results = analyzer(data);
 
-    aggregator.addToAggregate(results, url, statsHelpers);
+  aggregator.addToAggregate(results, url, statsHelpers);
 
-    if (typeof runIndex[url] === 'undefined') {
-        runIndex[url] = 0;
-    }
+  if (typeof runIndex[url] === "undefined") {
+    runIndex[url] = 0;
+  }
 
+  queue.postMessage(
+    make(
+      `${pluginName}.run`,
+      {
+        runIndex: runIndex[url],
+        data: results
+      },
+      {
+        url,
+        group,
+        runIndex: runIndex[url]
+      }
+    )
+  );
+
+  runIndex[url] = runIndex[url] + 1;
+
+  // Trigger pageSummary for each last run
+  if (runIndex[url] === options.iterations) {
     queue.postMessage(
-        make(
-            `${pluginName}.run`,
-            {
-                runIndex: runIndex[url],
-                data: results
-            },
-            {
-                url,
-                group,
-                runIndex
-            }
-        )
+      make(
+        `${pluginName}.pageSummary`,
+        aggregator.getSummary(url, statsHelpers),
+        {
+          url,
+          group
+        }
+      )
     );
-
-    runIndex[url] = runIndex[url] + 1;
-
-    // Trigger pageSummary for each last run
-    if (runIndex[url] === options.iterations) {
-        queue.postMessage(
-            make(
-                `${pluginName}.pageSummary`,
-                aggregator.getSummary(url, statsHelpers),
-                {
-                    url,
-                    group
-                }
-            )
-        );
-    }
+  }
 }
 
 module.exports = {
-    name() {
-        return pluginName;
-    },
+  name() {
+    return pluginName;
+  },
 
-    open(context, options) {
-        this.options = options.chrometrace || {};
-        this.options.iterations = options.browsertime.iterations;
-        this.statsHelpers = context.statsHelpers;
-    },
+  open(context, options) {
+    this.options = options.chrometrace || {};
+    this.options.iterations = options.browsertime.iterations;
+    this.statsHelpers = context.statsHelpers;
+    this.pug = fs.readFileSync(
+      path.resolve(__dirname, "src", "pug", "index.pug"),
+      "utf8"
+    );
+  },
 
-    processMessage(message, queue) {
-        if (message.type !== 'browsertime.chrometrace') {
-            return;
-        }
-
-        return processChrometraceMessage(
-            message,
-            queue,
-            this.statsHelpers,
-            this.options
-        );
+  processMessage(message, queue) {
+    if (message.type === "sitespeedio.setup") {
+      queue.postMessage(
+        make("html.pug", {
+          id: pluginName,
+          name: "Chrome trace",
+          pug: this.pug,
+          type: "run"
+        })
+      );
+      queue.postMessage(
+        make("html.pug", {
+          id: pluginName,
+          name: "Chrome trace",
+          pug: this.pug,
+          type: "pageSummary"
+        })
+      );
+      return;
+    } else if (message.type !== "browsertime.chrometrace") {
+      return;
     }
+
+    return processChrometraceMessage(
+      message,
+      queue,
+      this.statsHelpers,
+      this.options
+    );
+  }
 };

--- a/src/pug/index.pug
+++ b/src/pug/index.pug
@@ -1,0 +1,27 @@
+- const chromeTrace = pageInfo.data.browsertimeChrometrace.pageSummary || pageInfo.data.browsertimeChrometrace.run.data 
+
+.row
+  .one-half.column
+    h2 Activity
+    table
+        thead
+        tr
+            th Name
+            th Time (ms)
+        tbody
+            each value, key in chromeTrace.timeline.activity
+                tr
+                    td #{key}  
+                    td #{pageInfo.data.browsertimeChrometrace.pageSummary ? value.median : value.toFixed(4)}
+  .one-half.column
+    h2 Category
+    table
+        thead
+        tr
+            th Name
+            th Time (ms)
+        tbody
+            each value, key in chromeTrace.timeline.category
+                tr
+                    td #{key}  
+                    td #{pageInfo.data.browsertimeChrometrace.pageSummary ? value.median : value.toFixed(4)}


### PR DESCRIPTION
Added simple support to push the current metrics to HTML. If you could publish a stricter eslint config file I can reformat index.js the way you want it.
